### PR TITLE
Fixing tests

### DIFF
--- a/whynot/simulators/delayed_impact/fico.py
+++ b/whynot/simulators/delayed_impact/fico.py
@@ -118,15 +118,17 @@ def _get_pmf(cdf):
 def _loan_repaid_probs_factory(
     repay_df: DataFrame, scores: Index
 ) -> Iterable[Callable[[Array], Array]]:
-    """Given performance pd.DataFrame, construct mapping from X to p(Y|X)."""
 
     def repaid_probs_fn(query_scores: Array) -> Array:
         if isinstance(query_scores, np.ndarray):
             nearest_scores = _find_nearest_indices(scores, query_scores)
-            return repay_df[nearest_scores].values
+            return repay_df.iloc[nearest_scores].values
 
         query_score = query_scores
-        nearest_score = scores[scores.get_loc(query_score, method="nearest")]
+        nearest_score_idx = scores.get_indexer([query_score], method="nearest")[0]
+        if nearest_score_idx == -1:
+            raise ValueError(f"Query score {query_score} has no nearest value in scores.")
+        nearest_score = scores[nearest_score_idx]
         return repay_df[nearest_score]
 
     return repaid_probs_fn


### PR DESCRIPTION
We have quite a few failing:

- [x] FAILED tests/test_delayed_impact.py::test_repayment_fcn - TypeError: Index.get_loc() got an unexpected keyword argument 'method'
- [ ] FAILED tests/test_dynamics.py::test_basestate - AssertionError: assert 4 == 3
- [ ] FAILED tests/test_simulators.py::test_dynamics_initial_state[delayed_impact] - TypeError: Index.get_loc() got an unexpected keyword argument 'method'
- [ ] FAILED tests/test_simulators.py::test_dynamics_initial_state[credit] - IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
- [ ] FAILED tests/test_simulators.py::test_dynamics_initial_state[world3] - TypeError: 'JSObject' object is not iterable
- [ ] FAILED tests/test_simulators.py::test_dynamics_intervention[delayed_impact] - TypeError: Index.get_loc() got an unexpected keyword argument 'method'
- [ ] FAILED tests/test_simulators.py::test_dynamics_intervention[world3] - TypeError: 'JSObject' object is not iterable
- [ ] FAILED tests/test_simulators.py::test_simulator_experiments[delayed_impact] - TypeError: Index.get_loc() got an unexpected keyword argument 'method'
- [ ] FAILED tests/test_simulators.py::test_simulator_experiments[world3] - TypeError: 'JSObject' object is not iterable
- [ ] FAILED tests/test_simulators.py::test_parallelize[delayed_impact] - TypeError: Index.get_loc() got an unexpected keyword argument 'method'
- [ ] FAILED tests/test_simulators.py::test_parallelize[world3] - TypeError: 'JSObject' object is not iterable
- [ ] FAILED tests/test_world3.py::test_set_state - TypeError: 'JSObject' object is not iterable
- [ ] FAILED tests/gym_tests/test_envs.py::test_env[spec0] - IndexError: tuple index out of range
- [ ] FAILED tests/gym_tests/test_envs.py::test_env[spec1] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_env[spec2] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_env[spec3] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_env[spec4] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_random_rollout[HIV-v0] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_random_rollout[world3-v0] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_random_rollout[opioid-v0] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_config[HIV-v0] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_config[world3-v0] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_config[opioid-v0] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_config[Zika-v0] - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_envs.py::test_credit_config - IndexError: tuple index out of range
- [ ] FAILED tests/gym_tests/test_envs.py::test_credit_initial_state - IndexError: tuple index out of range
- [ ] FAILED tests/gym_tests/test_registration.py::test_make - TypeError: RandomNumberGenerator._generator_ctor() takes from 0 to 1 positional arguments but 2 we...
- [ ] FAILED tests/gym_tests/test_registration.py::test_malformed_lookup - AssertionError: Unexpected message: Malformed environment ID: “Breakout-v0”.(Currently all IDs mus...

